### PR TITLE
upgrade to newer version of memjs, use callback for set

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "dependencies": {
     "express": "2.5.x",
-    "memjs": "0.2.x"
+    "memjs": "0.8.x"
   },
   "engines": {
     "node": "0.6.x"

--- a/web.js
+++ b/web.js
@@ -16,8 +16,10 @@ app.get('/', function(request, response) {
 });
 
 app.get('/set/:value', function(request, response) {
-  memjs.set("latest", request.params.value);
-  response.redirect('/');
+  memjs.set("latest", request.params.value, function(err, success) {
+    if (err) { response.send(err); }
+    response.redirect('/');
+  });
 });
 
 var port = process.env.PORT || 3000;


### PR DESCRIPTION
The current memjs example hosted on heroku does not display when setting a value. this should fix issue #2 in the tracker.
